### PR TITLE
match versions of java in build + install

### DIFF
--- a/com.adamcake.Bolt.yml
+++ b/com.adamcake.Bolt.yml
@@ -33,7 +33,7 @@ modules:
   - name: openjdk
     buildsystem: simple
     build-commands:
-      - /usr/lib/sdk/openjdk17/install.sh
+      - /usr/lib/sdk/openjdk21/install.sh
   - shared-modules/gtk2/gtk2.json
   - name: openssl
     buildsystem: simple


### PR DESCRIPTION
Not sure why this passed PR checks. It actually does work as expected, somehow, but installs java 17 instead of 21.