### PR TITLE
Some improvements to the submodules script

### DIFF
--- a/generate-submodule-sources.py
+++ b/generate-submodule-sources.py
@@ -42,6 +42,8 @@ def parse_gitmodules(root, root_commit, relroot = None, out = None, target_hash_
                     parse_gitmodules(nextroot, commit, dest, out)
         elif line.startswith("url = "):
             module["url"] = line[6:]
+        elif line.startswith("gclient-condition"):
+            module["gclient-condition"] = line[20:] 
 
     f.close()
     return out

--- a/generate-submodule-sources.py
+++ b/generate-submodule-sources.py
@@ -100,6 +100,9 @@ if __name__ == "__main__" and argc > 0:
     # calculate (but dont store) a new set of modules based on the .gitmodules file regardless of if one exists
     # this is helpful for getting the raw paths from the repo for each submodule
     fresh_modules = parse_gitmodules(root, roothash, target_hash_lookup=target_hashes)
+
+    # filter out any with gclient-condition, which often designates them as internal.
+    fresh_modules = list(filter(lambda m: "internal" not in m.get("gclient-condition", "") , fresh_modules))
     
     existing_modules = get_existing_modules()
 

--- a/generate-submodule-sources.py
+++ b/generate-submodule-sources.py
@@ -52,7 +52,7 @@ def parse_gitmodules(root, root_commit, relroot = None, out = None, target_hash_
 def update_gitmodules(previous_modules, fresh_modules, target_hash_lookup):
     previous_by_url = {item['url']:item for item in previous_modules}
     fresh_by_url = {item['url']:item for item in fresh_modules}
-    all_urls = set(previous_by_url.keys()).intersection(set(fresh_by_url.keys()))
+    all_urls = set(previous_by_url.keys()).union(set(fresh_by_url.keys()))
     all_urls = sorted(list(all_urls))
 
     module_list = []

--- a/generate-submodule-sources.py
+++ b/generate-submodule-sources.py
@@ -116,7 +116,7 @@ if __name__ == "__main__" and argc > 0:
     fresh_modules = parse_gitmodules(root, roothash, target_hash_lookup=target_hashes)
 
     # filter out any with gclient-condition, which often designates them as internal.
-    fresh_modules = list(filter(lambda m: "internal" not in m.get("gclient-condition", "") , fresh_modules))
+    fresh_modules = list(filter(lambda m: "internal" not in m.get("gclient-condition", "") and "chrome-internal" not in m.get("url"), fresh_modules))
     
     existing_modules = get_existing_modules()
 

--- a/generate-submodule-sources.py
+++ b/generate-submodule-sources.py
@@ -68,6 +68,7 @@ def parse_module_target_hashes(root):
 
 argc = len(sys.argv)
 gitmodules_filename = ".gitmodules"
+submodule_yaml_filename = "chromium-submodules.yaml"
 
 if __name__ == "__main__" and argc > 0:
     if argc != 2:
@@ -80,7 +81,7 @@ if __name__ == "__main__" and argc > 0:
     roothash = result.stdout.decode("utf-8").strip()
     modules = parse_gitmodules(root, roothash, target_hash_lookup=target_hashes)#, relroot="chromium_git/chromium/src")
     
-    f = open("chromium-submodules.yaml", "w")
+    f = open(submodule_yaml_filename, "w")
     for module in modules:
         f.writelines([
             "- type: git\n",

--- a/generate-submodule-sources.py
+++ b/generate-submodule-sources.py
@@ -3,6 +3,7 @@
 import os
 import sys
 import subprocess
+import yaml
 
 def parse_gitmodules(root, root_commit, relroot = None, out = None, target_hash_lookup={}):
     if not out:
@@ -44,6 +45,11 @@ def parse_gitmodules(root, root_commit, relroot = None, out = None, target_hash_
     f.close()
     return out
 
+
+
+def get_existing_modules():
+    with open(submodule_yaml_filename, 'r') as file:
+        return yaml.safe_load(file)
 
 def parse_module_target_hashes(root):
     # https://stackoverflow.com/questions/20655073/how-to-see-which-commit-a-git-submodule-points-at?rq=3

--- a/generate-submodule-sources.py
+++ b/generate-submodule-sources.py
@@ -27,10 +27,10 @@ def parse_gitmodules(root, root_commit, relroot = None, out = None, target_hash_
             result = subprocess.run(["git", "-C", nextroot, "rev-parse", "HEAD"], stdout=subprocess.PIPE, stderr=subprocess.DEVNULL)
             # nonzero exit code probably means the directory doesn't exist at all
             if result.returncode == 0:
-                commit = result.stdout.decode("utf-8").strip()
+                commit = target_hash_lookup.get(dest)
                 # if the directory exists, but rev-parse returned the same hash as it did on the level above,
                 # that means the directory isn't a git repo in itself, so we should ignore it
-                if commit != root_commit:
+                if commit:
                     if relroot:
                         module["dest"] = os.path.join(relroot, dest)
                     else:


### PR DESCRIPTION
In trying to replicate this chromium build process on a slightly newer version of chromium, I noticed some ways to improve the script.

1. Use the git log to fetch the version that each submodule *should* be checked out to, as opposed to the version that's currently checked out (which may differ in the event of and uncommitted checkout of a different commit in a submodule). This also allows the script to work without needing to fully check out all the submodules (which can help for developers with space-constrained workstations)
2. Read from an existing submodule sources yaml file, should one exist. This ensures any custom changes made to paths are preserved by subsequent runs of the script
3. extract the `gclient-condition` value from `.gitmodules` and use that to enable filtering to be done from this script (since the README instructions weren't super clear on which things needed removing, so i just removed anything with "internal" in the gclient value, or anything with the internal subdomain in the url)
4. outputs submodules in alphabetical order by url

To facilitate the above, there are a few new functions:
-  the largest of these is `update_gitmodules`, which facilitates combining the previous  information from an existing YAML file, the newly-scraped gitmodules information, and a mapping of the expected commit for each submodule into a new list of modules that can be written to the file
- `parse_module_target_hashes` - parses the output of `git ls-tree` to determine which commit should be checked out for each submodule.  
- `get_existing_modules` reads the YAML file to pull in information from the existing sources.yaml file (only used for preserving the `dest`)


Remaining questions:
- was there some other logic to how you were filtering chromium submodules? i see now that my builds are pulling down a multi-gig webkit repo
- is it possible to running this on the existing chrome version for bolt and have it make no changes to the file (indicating that the logic for generating the .yaml sources file is a match for what you used)? i was having an issue trying to run the bolt build locally 