### PR TITLE
0.20.0

### DIFF
--- a/com.adamcake.Bolt.yml
+++ b/com.adamcake.Bolt.yml
@@ -314,9 +314,8 @@ modules:
       - -DBOLT_BINDIR=bin
       - -DBOLT_LIBDIR=lib
       - -DBOLT_SHAREDIR=share
-      - -DBOLT_LUAJIT_INCLUDE_DIR=/app/include/luajit-2.1
     sources:
       - type: git
         url: https://github.com/Adamcake/Bolt.git
-        tag: 0.19.1
-        commit: d9c2f90341db34c56895a516e8c1e5ceecaff694
+        tag: 0.20.0
+        commit: fb8e949c03f053ea947dae76e39010a1084a625a


### PR DESCRIPTION
In this version, we replaced proton (umu-launcher) with wine-staging for launching windows-only game clients, due to various stability issues. Therefore this PR reverts a lot of the config changes that were made with version 0.19.